### PR TITLE
Issue30

### DIFF
--- a/tarot_juicer/static/css/carousel.css
+++ b/tarot_juicer/static/css/carousel.css
@@ -2,10 +2,14 @@
 :root {
   --gap: 10px;
   --carousel-width: 80%;
+  --carousel-height: 230px;
 }
 
 .carousel {
-  width: var(--carousel-width);
+    width: var(--carousel-width);
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .hide {
@@ -90,7 +94,7 @@
   }
 
   to {
-    height: 350px;
+    height:  var(--carousel-height);
   }
 }
 
@@ -109,7 +113,7 @@
   }
 
   to {
-    height: 350px;
+    height: var(--carousel-height);
   }
 }
 
@@ -125,7 +129,7 @@
 @-webkit-keyframes hideCarousel {
   from {
     opacity: 1;
-    height: 350px;
+    height: var(--carousel-height);
     visibility: visible;
   }
 
@@ -145,7 +149,7 @@
 @keyframes hideCarousel {
   from {
     opacity: 1;
-    height: 350px;
+    height: var(--carousel-height);
     visibility: visible;
   }
 

--- a/tarot_juicer/static/css/carousel.css
+++ b/tarot_juicer/static/css/carousel.css
@@ -22,9 +22,8 @@
   display: grid;
   grid-gap: var(--gap);
   grid-template-columns: repeat(auto-fill, 1fr);
-  overflow: hidden;
-  padding: 20px 10px;
-  height: 70%;
+  overflow-x: hidden;
+  padding: 50px 10px;
 }
 
 /* Individual slide, contains images */

--- a/tarot_juicer/static/css/tarot_key.css
+++ b/tarot_juicer/static/css/tarot_key.css
@@ -485,7 +485,7 @@ h1,
   width: 100%; /* instead of width: auto */
   text-align: center;
   display: inline-block;
-  padding-top: -50px;
+  padding-top: 72px;
 }
 
 .flex-item {
@@ -545,9 +545,7 @@ img {
     ##Screen = B/w 768px to 1024px */
 @media (min-width: 768px) and (max-width: 1024px) and (orientation: landscape) {
 }
-#centered-buttons {
-  padding-top: -72px;
-}
+
 
 /* ##Device = Low Resolution Tablets, Mobiles (Landscape)
     ##Screen = B/w 481px to 767px */
@@ -559,7 +557,7 @@ img {
     max-width: 100px;
   }
   #centered-buttons {
-    padding-top: 50px;
+   
   }
 }
 

--- a/tarot_juicer/static/css/tarot_key.css
+++ b/tarot_juicer/static/css/tarot_key.css
@@ -485,7 +485,7 @@ h1,
   width: 100%; /* instead of width: auto */
   text-align: center;
   display: inline-block;
-  margin-top: -50px;
+  padding-top: -50px;
 }
 
 .flex-item {
@@ -546,8 +546,9 @@ img {
 @media (min-width: 768px) and (max-width: 1024px) and (orientation: landscape) {
 }
 #centered-buttons {
-  margin-top: -72px;
+  padding-top: -72px;
 }
+
 /* ##Device = Low Resolution Tablets, Mobiles (Landscape)
     ##Screen = B/w 481px to 767px */
 @media (min-width: 410px) and (max-width: 767px) {
@@ -558,7 +559,7 @@ img {
     max-width: 100px;
   }
   #centered-buttons {
-    margin-top: 50px;
+    padding-top: 50px;
   }
 }
 

--- a/tarot_juicer/static/js/carousel.js
+++ b/tarot_juicer/static/js/carousel.js
@@ -40,6 +40,7 @@ class Carousel {
 		this.gap = getCssVariable('--gap'); // used for width calculations
 		this.element = document.querySelector('.carousel');
 		this.isVisible = false;
+		this.buttons = document.querySelector('#centered-buttons');
 
 		// calculate slide width
 		this.slideWidth = parseInt(this.slides[0].offsetWidth);
@@ -100,6 +101,8 @@ class Carousel {
                 this.element.classList.remove('hide')
 		this.element.classList.remove('showCarousel')
 		this.element.classList.add('hideCarousel')
+		this.buttons.style.paddingTop = "72px"
+		
 	}
 
 	/* show carousel : applys showCarousel animation which changes visibility and height
@@ -109,6 +112,9 @@ class Carousel {
                         this.element.classList.remove('hide')
 			this.element.classList.remove('hideCarousel')
 			this.element.classList.add('showCarousel')
+			this.buttons.style.paddingTop = "0px"
+
+			
 	}
 
 	/* centers the carousel on the selected card / slide


### PR DESCRIPTION
These changes solved the problem on my system.  Moved height property for carousel into a css variable --carouse-height: 230px,  I found it was too tall initially.  Added JavaScript to control padding-top for buttons depending on visibility of carousel.  margin-top was changed to padding-top as padding is inside the box model while margin is outside the box model.  Thus keeping the button spacing isolated from carousel.  Glow from carousel extended into the buttons causing breakage with the hide /show which was resolved with reducing the padding of the slider to being just large enough to show the glow but small enough as to not interfere with button.  Because the carousel sliders (the container that contains the individual cards / slides) uses overflow hidden property  and a grid display mode, if its too small glow gets chopped off.  Let me know if this works.