### PR TITLE
Fixed git ingore file to hide db.sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,8 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
-db.sqlite3
-
+*.sqlite3
+*.bak
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
- [x] #50 hiding all .sqlite3 and .bak files.

> I simply add a recursive method to hide all .sqlite3 and .bak files from the repository. So it will hide all files ending with extension `.sqlite3` as `db.sqlite3` and `.bak` as `db.sqlite3.bak` ( which are sqlite3 backup files ).

That's all, I had done, thank you @enoren5 

Best Regards,
Umar Ahmed