### PR TITLE
Updated mistake in configuration

### DIFF
--- a/tarot_juicer/settings.py
+++ b/tarot_juicer/settings.py
@@ -90,7 +90,7 @@ WSGI_APPLICATION = 'tarot_juicer.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-if str(os.getenv('DATABASE_URL')) == None:
+if str(os.getenv('DATABASE_URL')) != 'None':
     DATABASES = {'default': dj_database_url.config(default=str(os.getenv('DATABASE_URL')), conn_max_age=600, ssl_require=True)}
 else:
     DATABASES = {


### PR DESCRIPTION
#### Mistake in conditioning

@enoren5 Brother,

```py
if str(os.getenv('DATABASE_URL')) == None: #BEFORE
```

```py
if str(os.getenv('DATABASE_URL')) != 'None': #AFTER
```
I just checking the `DATABASE_URL` in a wrong way, now if it is 'None' then it will check for local DB otherwise pick up DB from the `DATABASE_URL` string.

Sorry that was my mistake, for bad conditioning it
Best Regard
Umar Ahmed