### PR TITLE
Heroku locally remotely

### DIFF
--- a/tarot_juicer/settings.py
+++ b/tarot_juicer/settings.py
@@ -97,7 +97,7 @@ def check_env(environmental_variable):
 
 DATABASES = {
     'default': dj_database_url.config(
-        env=check_env("FIRST_DB") or check_env("THIRD_DB"),
+        env=check_env("FIRST_DB") or check_env("SECOND_DB"),
         default='sqlite:///'+os.path.join(BASE_DIR, 'db.sqlite3'), 
         conn_max_age=600)
     }

--- a/tarot_juicer/settings.py
+++ b/tarot_juicer/settings.py
@@ -88,25 +88,19 @@ WSGI_APPLICATION = 'tarot_juicer.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
-DATABASES = {}
 
-DB_HEROKU_POSTGRES = str(os.getenv('DB_HEROKU_POSTGRES'))
+def check_env(environmental_variable):
+    if environmental_variable in os.environ:
+        return environmental_variable
+    else:
+        return ""
 
-DB_HEROKU = str(os.getenv('DB_HEROKU'))
-
-if DB_HEROKU_POSTGRES != 'None':
-    DATABASES = {'default': dj_database_url.config(env="DB_HEROKU_POSTGRES", default=DB_HEROKU_POSTGRES, conn_max_age=600)}
-else:
-    if os.path.exists('db.sqlite3'):
-        DATABASES = {
-            'default': {
-                'ENGINE': 'django.db.backends.sqlite3',
-                'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-            },
-        }
-    else :
-        if DB_HEROKU != 'None':
-            DATABASES = {'default': dj_database_url.config(env="DB_HEROKU", default=DB_HEROKU, conn_max_age=600)}
+DATABASES = {
+    'default': dj_database_url.config(
+        env=check_env("FIRST_DB") or check_env("THIRD_DB"),
+        default='sqlite:///'+os.path.join(BASE_DIR, 'db.sqlite3'), 
+        conn_max_age=600)
+    }
 
 print(DATABASES)
 # Password validation


### PR DESCRIPTION
## THREE DATABASES SWAPPING

Hey @enoren5 

```python
# part #1
def check_env(environmental_variable):
    if environmental_variable in os.environ:
        return environmental_variable
    else:
        return ""

# part #2
DATABASES = {
    'default': dj_database_url.config(
        env=check_env("FIRST_DB") or check_env("THIRD_DB"),
        default='sqlite:///'+os.path.join(BASE_DIR, 'db.sqlite3'), 
        conn_max_age=600)
    }
```

- Now the above code have two parts, first one is a function that checks for a `environmental variable` ( in Heroku it is called config vars ), if a `environmental variable` is found then it simply returns its name other wise returns an empty string.


- Now the second part have a single dictionary object. having a `default` key with the value will be get from:

```python
dj_database_url.config() # method to get the DB configuration
```
- `dj_database_url` works as, it will first checks for the environmental variables for the parameter `env`:

- In our case, I made out a condition to check for two environmental variables called `FIRST_DB` and other is called `SECOND_DB`. 

- So it will check for `FIRST_DB` `environmental variable` ( in Heroku it is called config vars ), If it is present then it will use it.

- Other wise it checks `SECOND_DB`, If it is present then it will use it, other wise it will fallback to use default sqlite DB.

It will work like this:
```python
IF "FIRST_DB" exists

THEN "USE FIRST_DB AS DATABASE" 

ELSE IF "SECOND_DB" exists

THEN "USE SECOND_DB AS DATABASE" 

ELSE "USE DEFAULT SQLITE AS DATABASE"

```

#### So you can simply set the `FIRST_DB` as an `environmental variable` locally by running:

```python
export FIRST_DB=postgres://your-db-url
```
And to use on heroku you need to set a `config var` in the project setting is Heroku as:

```python
KEY=FIRST_DB

VALUE=postgres://your-db-url
```
And same for `SECOND_DB`, settings, 

- So by then ( when you have both vars setup ), If  `FIRST_DB` was not found then `SECOND_DB` will be set automatically and if both not found then it will fallback to use sqlite locally.

I hope now everything will be crystal clear to you brother. Let me know of any further confusion.

Best Regards
Umar Ahmed




