### PR TITLE
updated automation of swapping db

### DIFF
--- a/tarot_juicer/settings.py
+++ b/tarot_juicer/settings.py
@@ -102,7 +102,7 @@ print(SELECTED_DB)
 
 DATABASES = {
     'default': dj_database_url.config(
-        env=str(os.getenv('SELECTED_DB')),
+        env=str(os.getenv(SELECTED_DB)),
         default='sqlite:///'+os.path.join(BASE_DIR, 'db.sqlite3'), 
         conn_max_age=600)
     }

--- a/tarot_juicer/settings.py
+++ b/tarot_juicer/settings.py
@@ -95,10 +95,11 @@ VALUE = os.getenv('SELECT_DB')
 
 if VALUE == "0":
     SELECTED_DB = "HEROKU_POSTGRESQL_SILVER_URL"
-else:
-    SELECTED_DB = "HEROKU_POSTGRESQL_NAVY_URL"
+else :
+    if VALUE == "1":
+        SELECTED_DB = "HEROKU_POSTGRESQL_NAVY_URL"
 
-print(SELECTED_DB)
+print(SELECTED_DB, VALUE)
 
 DATABASES = {
     'default': dj_database_url.config(


### PR DESCRIPTION
Updated automation of swapping DBs
```python
SELECTED_DB = "" # initialize a avariable

VALUE = os.getenv('SELECT_DB')  # here we fetch value from heroku

if VALUE == "0": # checking which DB to select
    SELECTED_DB = "HEROKU_POSTGRESQL_SILVER_URL"
else:
    SELECTED_DB = "HEROKU_POSTGRESQL_NAVY_URL"

print(SELECTED_DB) # confirm it

DATABASES = {
    'default': dj_database_url.config(
        env=str(os.getenv(SELECTED_DB)),  # Now put the selected DB here
        default='sqlite:///'+os.path.join(BASE_DIR, 'db.sqlite3'), 
        conn_max_age=600)
    }
```