### PR TITLE
more-on-handeling-DBs

### DIFF
--- a/tarot_juicer/settings.py
+++ b/tarot_juicer/settings.py
@@ -89,23 +89,15 @@ WSGI_APPLICATION = 'tarot_juicer.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-SELECTED_DB = ""
+# TODO: Run  `export DATABASE_URL=postgres://USER:PASSWORD@HOST:PORT/NAME` 
+#       To use AWS Postgres db’s locally
 
-VALUE = os.getenv('SELECT_DB')
-
-if VALUE == "0":
-    SELECTED_DB = "HEROKU_POSTGRESQL_SILVER_URL"
-elif VALUE == "1":
-    SELECTED_DB = "HEROKU_POSTGRESQL_NAVY_URL"
-
+DATABASES = {}
 DATABASES = {
-    'default': dj_database_url.config(
-        env=SELECTED_DB,
-        default='sqlite:///'+os.path.join(BASE_DIR, 'db.sqlite3'), 
-        conn_max_age=600)
-    }
-
-print(DATABASES)
+   'default': dj_database_url.config(
+       default='sqlite:///'+os.path.join(BASE_DIR, 'db.sqlite3'),
+       conn_max_age=600)
+   }
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 
@@ -149,9 +141,7 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 MEDIA_ROOT = os.path.join(STATIC_ROOT, 'img')
 MEDIA_URL = 'img/'
 
-django_heroku.settings(locals(), databases=False)
-#del DATABASES['default']['OPTIONS']['sslmode']
-#print(DATABASES)
+django_heroku.settings(locals())
 
 MESSAGE_TAGS = {
     messages.ERROR: 'danger',


### PR DESCRIPTION
## Issue 1 and 2 (SOLVED)

```python
DATABASES = {}
DATABASES = {
   'default': dj_database_url.config(
       default='sqlite:///'+os.path.join(BASE_DIR, 'db.sqlite3'),
       conn_max_age=600)
   }
```

**dj_database_url** always check for a environmental variable named `DATABASE_URL`, if it is found then, it will setup that, and else it will fall back to use sqlite locally.

### REMOTE CONFIGURATIONS:

> For remote DBs, the `DATABASE_URL` works automatically on Heroku, as Heroku apps use the `DATABASE_URL` config var to designate the URL of an app’s primary database. If your app only has one database, its URL is automatically assigned to this config var.

And for the swapping of Dbs as you know, we use to run `heroku pg:promote` command to set the primary database. So if you run `heroku pg:promote HEROKU_POSTGRESQL_ROSE` then Heroku will assign `HEROKU_POSTGRESQL_ROSE`'s value to `DATABASE_URL` automatically and thus, allows your app to be able to use the `HEROKU_POSTGRESQL_ROSE` DB. 

> #### Note: And this will be applied to any Db you assigned using `heroku pg:promote` command

### LOCAL CONFIGURATIONS:

> For local DBs, the `DATABASE_URL` works like if an environmental variable is not found then djiango will start using Sqlite locally as default DB.

But if you want to use aws db locally, then you need to execute only one command as:
```python
export DATABASE_URL=postgres://USER:PASSWORD@HOST:PORT/NAME
```
Then djiango will start using aws db locally. And if you want to use again sqlite, then you can delete the env. var. by
```python
unset DATABASE_URL
```
Now, as per the issue 1 and issue 2 are solved based on given instruction.

Thank you @enoren5 :grinning: 
