### PR TITLE
Update nuclear bug

### DIFF
--- a/tarot_juicer/middlewares.py
+++ b/tarot_juicer/middlewares.py
@@ -48,10 +48,10 @@ def authentication_middleware(get_response):
             "nuclear": nuclear,
             "protection": AuthToggle.objects.first()
         }
+
         if nuclear:
             if isLoggedIn :
-                if not admin_path:
-                    return render(request, 'landings/portal.html', context)
+                pass
             else:
                 if not admin_path:
                     return render(request, 'landings/gateway.html', context)


### PR DESCRIPTION
# Issue-Bug in `nuclear` toggling


In previous code, when `isLoggedIn` is `true` then middleware redirects user to portal only, even when admin is logged in. So the change I made is that, When admin is logged in and use the portal then, do `pass` over and don't apply restrictions.

that's all I had done @enoren5 brother